### PR TITLE
.error(...) continuation support

### DIFF
--- a/include/async++/scheduler_fwd.h
+++ b/include/async++/scheduler_fwd.h
@@ -28,6 +28,7 @@ namespace async {
 class task_run_handle;
 class LIBASYNC_EXPORT scheduler {
 public:
+    virtual ~scheduler(){}
 	// Schedule a task for execution.
 	virtual void schedule(task_run_handle t) = 0;
 };


### PR DESCRIPTION
User can specify a .error(…) function that gets called only if
.cancel() is called on a parent task.
This is useful to implement a Promise like functionality using
event_task, so that it can be “fullfilled” by calling set or “rejected”
by calling .cancel()

Example:

``` c++

#define LIBASYNC_DEFAULT_SCHEDULER async::inline_scheduler()
#include <async++.h>

template<typename T>
using Promise = async::event_task<T>;

int main(int argc, const char * argv[])
{
    using namespace async;

    // Create an event
    Promise<int> e;

    // Get a task associated with the event
    auto t = e.get_task();

    decltype(e) e1;
    // Add a continuation to the task
    t
    .then([&](int result)
    {
        printf("then1=%d\n",result);
        return result + 1;
    })
    .then([](int result)
    {
        printf("then2=%d\n",result);
        return result + 1.5;
    })
    .then([](float result)
    {
        printf("then3=%f\n",result);
        return result;
    })
    .error([](int res)
    {
        //executed only if e.cancel() is called
        printf("Task 1 ERROR occurred\n");
        return res;
    }).then([&](int res)
    {
        printf("THIS IS ALWAYS executed\n");
        return e1.get_task();
    }).then([&](int res)
    {
        printf("Task 2 executed\n");
        return res;
    }).error([](int res)
    {
        //executed only if e1.cancel() is called
        printf("Task 2 ERROR occurred\n");
    });

    // Set the event value, which will cause the continuation to run
    e.set(42);
    e1.set(44);
    //e.cancel();
    //e1.cancel();
    printf("End of program\n");

    return 0;
}
```
