### PR TITLE
Implement a thread_local emulation for iOS devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ The only requirement to use Async++ is a C++11 compiler and standard library. Un
 
 - Linux: Works with GCC 4.7+, Clang 3.2+ and Intel compiler 15+.
 - Mac: Works with Apple Clang (using libc++). GCC also works but you must get a recent version (4.7+).
+- iOS: Works with Apple Clang (using libc++). Note: because iOS has no thread local support, the library uses a workaround based on pthreads.
 - Windows: Works with GCC 4.8+ (with pthread-win32) and Visual Studio 2013+.
 
 Building and Installing

--- a/src/internal.h
+++ b/src/internal.h
@@ -68,6 +68,19 @@
 # define BROKEN_JOIN_IN_DESTRUCTOR
 #endif
 
+// Apple's iOS has no thread local support yet. They claim that they don't want to
+// introduce a binary compatility issue when they got a better implementation available.
+// Luckily, pthreads supports some kind of "emulation" for that. This detects if the we
+// are compiling for iOS and enables the workaround accordingly.
+// It is also possible enabling it forcibly by setting the EMULATE_PTHREAD_THREAD_LOCAL
+// macro. Obviously, this will only works on platforms with pthread available.
+#if __APPLE__
+# include "TargetConditionals.h"
+# if TARGET_IPHONE_SIMULATOR || TARGET_OS_IPHONE
+#  define EMULATE_PTHREAD_THREAD_LOCAL
+# endif
+#endif
+
 // Force symbol visibility to hidden unless explicity exported
 #if defined(__GNUC__) && !defined(_WIN32)
 # pragma GCC visibility push(hidden)


### PR DESCRIPTION
Apparently Apple does not implement any compiler based thread local storage on iOS. But pthread is capable of storing thread local data.

This pull requests adds a macro called **EMULATE_PTHREAD_THREAD_LOCAL** that enables the emulation.

I have also changed the way the thread-global variables are accessed because pthread cannot map transparently to a variable (it could be done with templates... but i tried to keep it simple): a function is used to setup, get and set a thread local instead of a variable directly.