### PR TITLE
Make debian package creation easy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,3 +129,8 @@ else()
 	install(FILES ${PROJECT_SOURCE_DIR}/include/async++.h DESTINATION include)
 	install(FILES ${ASYNCXX_INCLUDE} DESTINATION include/async++)
 endif()
+
+SET(CPACK_GENERATOR "DEB")
+SET(CPACK_DEBIAN_PACKAGE_MAINTAINER "none") #required
+
+INCLUDE(CPack)


### PR DESCRIPTION
With this, running 
```
cmake ..
make package 
dpkg -i Async++-0.1.1-Linux.deb
```

is sufficient to install async++ on debian-like systems.