### PR TITLE
Visibility not needed for static build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,13 +77,13 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 target_link_libraries(Async++ PUBLIC Threads::Threads)
 
-# Minimize the set of symbols exported by libraries
-set_target_properties(Async++ PROPERTIES CXX_VISIBILITY_PRESET hidden VISIBILITY_INLINES_HIDDEN ON)
-
 # Set up preprocessor definitions
 target_include_directories(Async++ PRIVATE ${PROJECT_SOURCE_DIR}/include)
 set_target_properties(Async++ PROPERTIES DEFINE_SYMBOL LIBASYNC_BUILD)
-if (NOT BUILD_SHARED_LIBS)
+if (BUILD_SHARED_LIBS)
+	# Minimize the set of symbols exported by libraries
+	set_target_properties(Async++ PROPERTIES CXX_VISIBILITY_PRESET hidden VISIBILITY_INLINES_HIDDEN ON)
+else()
 	target_compile_definitions(Async++ PUBLIC LIBASYNC_STATIC)
 endif()
 

--- a/include/async++.h
+++ b/include/async++.h
@@ -114,8 +114,10 @@
 #endif
 
 // Force symbol visibility to hidden unless explicity exported
+#ifndef LIBASYNC_STATIC
 #if defined(__GNUC__) && !defined(_WIN32)
 # pragma GCC visibility push(hidden)
+#endif
 #endif
 
 // Some forward declarations
@@ -147,8 +149,10 @@ class event_task;
 #include "async++/parallel_for.h"
 #include "async++/parallel_reduce.h"
 
+#ifndef LIBASYNC_STATIC
 #if defined(__GNUC__) && !defined(_WIN32)
 # pragma GCC visibility pop
+#endif
 #endif
 
 #endif

--- a/src/internal.h
+++ b/src/internal.h
@@ -82,8 +82,10 @@
 #endif
 
 // Force symbol visibility to hidden unless explicity exported
+#ifndef LIBASYNC_STATIC
 #if defined(__GNUC__) && !defined(_WIN32)
 # pragma GCC visibility push(hidden)
+#endif
 #endif
 
 // Include other internal headers

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -239,6 +239,8 @@ wait_handler set_thread_wait_handler(wait_handler handler) LIBASYNC_NOEXCEPT
 
 } // namespace async
 
+#ifndef LIBASYNC_STATIC
 #if defined(__GNUC__) && !defined(_WIN32)
 # pragma GCC visibility pop
+#endif
 #endif

--- a/src/threadpool_scheduler.cpp
+++ b/src/threadpool_scheduler.cpp
@@ -434,6 +434,8 @@ void threadpool_scheduler::schedule(task_run_handle t)
 
 } // namespace async
 
+#ifndef LIBASYNC_STATIC
 #if defined(__GNUC__) && !defined(_WIN32)
 # pragma GCC visibility pop
+#endif
 #endif


### PR DESCRIPTION
This also fixes CMake and gcc warnings when integrating async++ as a subproject.