### PR TITLE
Missing include of CMakeFindDependencyMacro

### DIFF
--- a/Async++Config.cmake.in
+++ b/Async++Config.cmake.in
@@ -1,2 +1,3 @@
+include(CMakeFindDependencyMacro)
 find_dependency(Threads)
 include("${CMAKE_CURRENT_LIST_DIR}/Async++.cmake")


### PR DESCRIPTION
Missing include of CMakeFindDependencyMacro to be able to use find_dependency function.