### PR TITLE
add support for no(void) parameter continuations

### DIFF
--- a/include/async++/task.h
+++ b/include/async++/task.h
@@ -70,7 +70,7 @@ class basic_task {
 		// Create continuation
 		typedef continuation_traits<Parent, Func> traits;
 		typedef typename void_to_fake_void<typename traits::task_type::result_type>::type cont_internal_result;
-		typedef continuation_exec_func<Sched, typename std::decay<Parent>::type, cont_internal_result, typename traits::decay_func, traits::is_value_cont::value, is_task<typename traits::result_type>::value> exec_func;
+		typedef continuation_exec_func<Sched, typename std::decay<Parent>::type, cont_internal_result, typename traits::decay_func, typename traits::is_value_cont, is_task<typename traits::result_type>::value> exec_func;
 		typename traits::task_type cont;
 		set_internal_task(cont, task_ptr(new task_func<Sched, exec_func, cont_internal_result>(std::forward<Func>(f), std::forward<Parent>(parent))));
 

--- a/include/async++/traits.h
+++ b/include/async++/traits.h
@@ -114,6 +114,8 @@ typename void_to_fake_void<decltype(std::declval<Func>()())>::type invoke_fake_v
 }
 
 // Various properties of a continuation function
+template<typename Func, typename Parent, typename = decltype(std::declval<Func>()())>
+fake_void is_value_cont_helper(const Parent&, int, int);
 template<typename Func, typename Parent, typename = decltype(std::declval<Func>()(std::declval<Parent>().get()))>
 std::true_type is_value_cont_helper(const Parent&, int, int);
 template<typename Func, typename = decltype(std::declval<Func>()())>
@@ -129,7 +131,7 @@ struct continuation_traits {
 	typedef typename std::decay<Func>::type decay_func;
 	typedef decltype(detail::is_value_cont_helper<decay_func>(std::declval<Parent>(), 0, 0)) is_value_cont;
 	static_assert(!std::is_void<is_value_cont>::value, "Parameter type for continuation function is invalid for parent task type");
-	typedef typename std::conditional<is_value_cont::value, typename void_to_fake_void<decltype(std::declval<Parent>().get())>::type, Parent>::type param_type;
+	typedef typename std::conditional_t<std::is_same_v<is_value_cont, fake_void>, fake_void, typename std::conditional<std::is_same_v<is_value_cont, std::true_type>, typename void_to_fake_void<decltype(std::declval<Parent>().get())>::type, Parent>::type> param_type;
 	typedef decltype(detail::fake_void_to_void(detail::invoke_fake_void(std::declval<decay_func>(), std::declval<param_type>()))) result_type;
 	typedef task<typename remove_task<result_type>::type> task_type;
 };

--- a/include/async++/traits.h
+++ b/include/async++/traits.h
@@ -131,7 +131,7 @@ struct continuation_traits {
 	typedef typename std::decay<Func>::type decay_func;
 	typedef decltype(detail::is_value_cont_helper<decay_func>(std::declval<Parent>(), 0, 0)) is_value_cont;
 	static_assert(!std::is_void<is_value_cont>::value, "Parameter type for continuation function is invalid for parent task type");
-	typedef typename std::conditional_t<std::is_same_v<is_value_cont, fake_void>, fake_void, typename std::conditional<std::is_same_v<is_value_cont, std::true_type>, typename void_to_fake_void<decltype(std::declval<Parent>().get())>::type, Parent>::type> param_type;
+	typedef typename std::conditional_t<std::is_same<is_value_cont, fake_void>::value, fake_void, typename std::conditional<std::is_same<is_value_cont, std::true_type>::value, typename void_to_fake_void<decltype(std::declval<Parent>().get())>::type, Parent>::type> param_type;
 	typedef decltype(detail::fake_void_to_void(detail::invoke_fake_void(std::declval<decay_func>(), std::declval<param_type>()))) result_type;
 	typedef task<typename remove_task<result_type>::type> task_type;
 };

--- a/include/async++/traits.h
+++ b/include/async++/traits.h
@@ -131,7 +131,7 @@ struct continuation_traits {
 	typedef typename std::decay<Func>::type decay_func;
 	typedef decltype(detail::is_value_cont_helper<decay_func>(std::declval<Parent>(), 0, 0)) is_value_cont;
 	static_assert(!std::is_void<is_value_cont>::value, "Parameter type for continuation function is invalid for parent task type");
-	typedef typename std::conditional_t<std::is_same<is_value_cont, fake_void>::value, fake_void, typename std::conditional<std::is_same<is_value_cont, std::true_type>::value, typename void_to_fake_void<decltype(std::declval<Parent>().get())>::type, Parent>::type> param_type;
+	typedef typename std::conditional<std::is_same<is_value_cont, fake_void>::value, fake_void, typename std::conditional<std::is_same<is_value_cont, std::true_type>::value, typename void_to_fake_void<decltype(std::declval<Parent>().get())>::type, Parent>::type>::type param_type;
 	typedef decltype(detail::fake_void_to_void(detail::invoke_fake_void(std::declval<decay_func>(), std::declval<param_type>()))) result_type;
 	typedef task<typename remove_task<result_type>::type> task_type;
 };


### PR DESCRIPTION
Feature description: 
- Support continuations with no(void) parameters to arbitrary tasks

Use case: 
- It's benefitial to be able to easily add callback or notification tasks that do not care about particular task results

It's possible to workaround in current state by using generic no-op lambda continuations
> task_with_result.then(inline_sched(), [](auto p){}).then(...);

but has the added benefit of handling the case when e.g. 
> task_with_result = when_all(...);


Suggested changes to the wiki/Tasks page:

>The function passed must take 0 or 1 parameter

>In case the function takes 0 parameters the return values of the parent task are discarded
