### PR TITLE
Add explicit move constructor / move assignment for shared_task

### DIFF
--- a/include/async++/task.h
+++ b/include/async++/task.h
@@ -294,6 +294,17 @@ public:
 	// Movable and copyable
 	shared_task() = default;
 
+	// Move constructor for task	
+	shared_task(task<Result>&& other) LIBASYNC_NOEXCEPT
+		: detail::basic_task<Result>(std::move(other)) {}
+
+	// Move-assignment for task
+	shared_task& operator=(task<Result>&& other) LIBASYNC_NOEXCEPT
+	{
+		detail::basic_task<Result>::operator=(std::move(other));
+		return *this;
+	}
+
 	// Get the result of the task
 	get_result get() const
 	{

--- a/include/async++/task_base.h
+++ b/include/async++/task_base.h
@@ -65,13 +65,13 @@ struct LIBASYNC_CACHELINE_ALIGN task_base: public ref_count_base<task_base, task
 	std::atomic<task_state> state;
 
 	// Whether get_task() was already called on an event_task
-	bool event_task_got_task;
+	bool event_task_got_task{};
 
 	// Vector of continuations
 	continuation_vector continuations;
 
 	// Virtual function table used for dynamic dispatch
-	const task_base_vtable* vtable;
+	const task_base_vtable* vtable{};
 
 	// Use aligned memory allocation
 	static void* operator new(std::size_t size)


### PR DESCRIPTION
When upgrading to using gcc-11 with C++ 20, it is no longer possible to assign a task to a shared_task as in:

```
async::shared_task<cb_result> task{async::make_task(cb_result::CB_S_OK)};
```

Therefore an explicit move-constructor and move-assignment operator have been added to shared_task:

```
	shared_task(task<Result>&& other)
	shared_task& operator=(task<Result>&& other)
```