### PR TITLE
Replace deprecated std::aligned_storage with alternative

### DIFF
--- a/include/async++/task_base.h
+++ b/include/async++/task_base.h
@@ -166,8 +166,8 @@ struct task_base_deleter {
 template<typename Result>
 struct task_result_holder: public task_base {
 	union {
-		typename std::aligned_storage<sizeof(Result), std::alignment_of<Result>::value>::type result;
-		std::aligned_storage<sizeof(std::exception_ptr), std::alignment_of<std::exception_ptr>::value>::type except;
+		alignas(Result) std::uint8_t result[sizeof(Result)];
+		alignas(std::exception_ptr) std::uint8_t except[sizeof(std::exception_ptr)];
 
 		// Scheduler that should be used to schedule this task. The scheduler
 		// type has been erased and is held by vtable->schedule.
@@ -208,7 +208,7 @@ struct task_result_holder<Result&>: public task_base {
 	union {
 		// Store as pointer internally
 		Result* result;
-		std::aligned_storage<sizeof(std::exception_ptr), std::alignment_of<std::exception_ptr>::value>::type except;
+		alignas(std::exception_ptr) std::uint8_t except[sizeof(std::exception_ptr)];
 		void* sched;
 	};
 
@@ -233,7 +233,7 @@ struct task_result_holder<Result&>: public task_base {
 template<>
 struct task_result_holder<fake_void>: public task_base {
 	union {
-		std::aligned_storage<sizeof(std::exception_ptr), std::alignment_of<std::exception_ptr>::value>::type except;
+		alignas(std::exception_ptr) std::uint8_t except[sizeof(std::exception_ptr)];
 		void* sched;
 	};
 
@@ -344,7 +344,7 @@ struct func_base<Func, typename std::enable_if<std::is_empty<Func>::value>::type
 // Class to hold a function object and initialize/destroy it at any time
 template<typename Func, typename = void>
 struct func_holder {
-	typename std::aligned_storage<sizeof(Func), std::alignment_of<Func>::value>::type func;
+	alignas(Func) std::uint8_t func[sizeof(Func)];
 
 	Func& get_func()
 	{

--- a/src/singleton.h
+++ b/src/singleton.h
@@ -39,7 +39,7 @@ template<typename T>
 class singleton {
 	std::mutex lock;
 	std::atomic<bool> init_flag;
-	typename std::aligned_storage<sizeof(T), std::alignment_of<T>::value>::type storage;
+	alignas(T) std::uint8_t storage[sizeof(T)];
 
 	static singleton instance;
 

--- a/src/task_wait_event.h
+++ b/src/task_wait_event.h
@@ -35,8 +35,8 @@ enum wait_type {
 //
 // The event object is lazily initialized to avoid unnecessary API calls.
 class task_wait_event {
-	std::aligned_storage<sizeof(std::mutex), std::alignment_of<std::mutex>::value>::type m;
-	std::aligned_storage<sizeof(std::condition_variable), std::alignment_of<std::condition_variable>::value>::type c;
+	alignas(std::mutex) std::uint8_t m[sizeof(std::mutex)];
+	alignas(std::condition_variable) std::uint8_t c[sizeof(std::condition_variable)];
 	int event_mask;
 	bool initialized;
 


### PR DESCRIPTION
[std::aligned_storage is being deprecated in C++23](https://en.cppreference.com/w/cpp/types/aligned_storage) (more information [here](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p1413r3.pdf)). Even though this is a C++11 library, some compilers will still emit warnings about it (such as when the header is included in a project that is compiled with C++20+).

This pull request replaces all uses of `std::aligned_storage` with alternatives suggested in [this StackOverflow post](https://stackoverflow.com/questions/71828288/why-is-stdaligned-storage-to-be-deprecated-in-c23-and-what-to-use-instead) and [this section in cppreference](https://en.cppreference.com/w/cpp/types/aligned_storage#Possible_implementation).